### PR TITLE
Change currency symbol to "Mg"

### DIFF
--- a/forms.lua
+++ b/forms.lua
@@ -1,4 +1,5 @@
-
+-- abbreviation/symbol of the currency
+local MONEY_SYMBOL = "Mg" -- Mg = Minegeld
 
 function atm.showform (player)
 	atm.read_account(player:get_player_name())
@@ -9,7 +10,7 @@ function atm.showform (player)
 	default.gui_slots..
 	"label[1.25,0.5;Money input]" ..
 	"label[5.25,0.5;Money output]" ..
-	"label[2.5,0.15;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
+	"label[2.5,0.15;Your account balance: ".. atm.balance[player:get_player_name()].. " " .. MONEY_SYMBOL .. "]" ..
 	"button_exit[2.5,1.5;1,2;Quit;Quit]" ..
 	"item_image_button[0.5,1;1,1;".. "currency:minegeld" ..";i1;\n\n\b\b\b\b\b" .. "1" .."]" ..
 	"item_image_button[1.5,1;1,1;".. "currency:minegeld_5" ..";i5;\n\n\b\b\b\b\b" .. "1" .."]" ..
@@ -36,7 +37,7 @@ function atm.showform2 (player)
 	default.gui_slots..
 	"label[1.25,0.5;Money input]" ..
 	"label[5.25,0.5;Money output]" ..
-	"label[2.5,0.15;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
+	"label[2.5,0.15;Your account balance: ".. atm.balance[player:get_player_name()].. " " .. MONEY_SYMBOL .. "]" ..
 	"button_exit[2.5,2.5;1,2;Quit;Quit]" ..
 	"item_image_button[0.5,1;1,1;".. "currency:minegeld" ..";i1;\n\n\b\b\b\b\b" .. "1" .."]" ..
 	"item_image_button[1.5,1;1,1;".. "currency:minegeld_5" ..";i5;\n\n\b\b\b\b\b" .. "1" .."]" ..
@@ -69,7 +70,7 @@ function atm.showform3 (player)
 	default.gui_slots..
 	"label[1.25,0.5;Money input]" ..
 	"label[5.25,0.5;Money output]" ..
-	"label[2.5,0.15;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
+	"label[2.5,0.15;Your account balance: ".. atm.balance[player:get_player_name()].. " " .. MONEY_SYMBOL .. "]" ..
 	"button_exit[3.5,2.75;1,2;Quit;Quit]" ..
 	"item_image_button[0.5,1;1,1;".. "currency:minegeld" ..";i1;\n\n\b\b\b\b\b" .. "1" .."]" ..
 	"item_image_button[1.5,1;1,1;".. "currency:minegeld_5" ..";i5;\n\n\b\b\b\b\b" .. "1" .."]" ..
@@ -111,7 +112,7 @@ function atm.showform_wt (player)
 	default.gui_slots..
 	"button[5.75,0;2,1;transactions;Transactions >]" ..
 	"label[2.5,0;Wire Transfer Terminal]" ..
-	"label[2,0.5;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
+	"label[2,0.5;Your account balance: ".. atm.balance[player:get_player_name()].. " " .. MONEY_SYMBOL .. "]" ..
 	"field[0.5,1.5;5,1;dstn;Recepient:;]"..
 	"field[6,1.5;2,1;amnt;Amount:;]"..
 	"field[0.5,3;7.5,1;desc;Description:;]"..
@@ -130,7 +131,7 @@ function atm.showform_wtconf (player, dstn, amnt, desc)
 	default.gui_bg_img..
 	default.gui_slots..
 	"label[2.5,0;Wire Transfer Terminal]" ..
-	"label[2,0.5;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
+	"label[2,0.5;Your account balance: ".. atm.balance[player:get_player_name()].. " " .. MONEY_SYMBOL .. "]" ..
 	"label[2.5,1;TRANSACTION SUMMARY:]"..
 	"label[0.5,1.5;Recepient: " .. dstn .. "]"..
 	"label[0.5,2;Amount: " .. amnt .. "]"..
@@ -151,7 +152,7 @@ function atm.showform_wtlist (player, tlist)
 		textlist = "no transactions registered\n"
 	else
 		for _, entry in ipairs(tlist) do
-			textlist = textlist .. entry.date .. " $" .. entry.sum .. " from " .. entry.from .. ": " .. entry.desc .. "\n"
+			textlist = textlist .. entry.date .. " " .. entry.sum .. " " .. MONEY_SYMBOL .. " from " .. entry.from .. ": " .. entry.desc .. "\n"
 		end
 	end
 
@@ -162,7 +163,7 @@ function atm.showform_wtlist (player, tlist)
 	default.gui_slots..
 	"button[5.75,0;2,1;transfer;< Transfer money]" ..
 	"label[2.5,0;Wire Transfer Terminal]" ..
-	"label[2,0.5;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
+	"label[2,0.5;Your account balance: ".. atm.balance[player:get_player_name()].. " " .. MONEY_SYMBOL .. "]" ..
 	"textarea[0.5,1.25;7.5,4;hst;Transaction list;" .. textlist .. "]" ..
 	"button_exit[0.2,5;1,1;Quit;Quit]" ..
 	"button[4.7,5;3,1;clr;Clear transactions]"


### PR DESCRIPTION
This PR changes the currency symbol shown in formspecs to "Mg" because the currency is Minegeld, not dollars. This is also the symbol used in the `currency` mod.