### PR TITLE
50 and 100 Minegeld notes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,46 @@
 # ATM mod for Minetest
 
-This mod adds a faimly of ATM machines designed to work with the currency mod and its
-minegeld banknotes. ATMs allow you to transfer money to your bank account and withdraw
+This mod adds a faimly of ATMs (Automated Teller Machines) designed to work with the currency
+mod and its Minegeld banknotes. ATMs allow you to transfer money to your bank account and withdraw
 various sums as needed.
 
-There are 3 types of ATMs with different capabilities. The most basic version is grey and
-only allows single banknote transactions.
+## ATMs
+
+There are 3 types of ATMs with different capabilities.
+
+### ATM
+The most basic version is grey and blue and only allows single banknote transactions
+with Minegeld notes of value 1, 5 and 10.
 
 ```
 [ steel ingot, mese wire, steel ingot ]
-[ glass,       1 MG note, steel ingot ]
+[ glass,       1 Mg note, steel ingot ]
 [ steel ingot, mese wire, steel ingot ]
 ```
 
-The more advanced, green ATM, allows transactions in bundles of 10 notes.
+### ATM Model 2
+The more advanced, brownish and purple ATM, allows transactions in bundles of 10 notes
+with Minegeld notes of value 1, 5, 10 and 50.
 
 ```
 [ steel ingot, mese wire,    steel ingot ]
-[ glass,       5 MG note,    steel ingot ]
+[ glass,       5 Mg note,    steel ingot ]
 [ steel ingot, mese crystal, steel ingot ]
 ```
 
-The most advanced ATM, the yellow one, allows to add and withdraw banknotes by hundreds.
+### ATM Model 3
+The most advanced ATM, the yellow and red one, allows to add and withdraw banknotes by hundreds
+with Minegeld notes of value 1, 5, 10, 50 and 100.
 
 ```
 [ steel ingot, mese crystal, steel ingot ]
-[ glass,       10 MG note,   steel ingot ]
+[ glass,       10 Mg note,   steel ingot ]
 [ steel ingot, mese crystal, steel ingot ]
 ```
 
-Goes without saying, all lower tier options are also available in a higher tier ATM.
+### Crafting note
 
-If mesecons mod is not installed, then the mese wire in recipes is replaced by a copper ingot.
+If the Mesecons mod is not installed, then the mese wire in recipes is replaced by a copper ingot.
 
 ## Wire Transfer
 

--- a/forms.lua
+++ b/forms.lua
@@ -117,7 +117,7 @@ function atm.showform3 (player)
 	end
 	if mg100_exists then
 		xplus = xplus + 1.5
-		listx = listx + 0.5
+		listx = listx + 0.75
 		cols = cols + 1
 		gap = 0.5
 	end

--- a/forms.lua
+++ b/forms.lua
@@ -2,18 +2,6 @@
 local mg50_exists = minetest.registered_items["currency:minegeld_50"] ~= nil
 local mg100_exists = minetest.registered_items["currency:minegeld_100"] ~= nil
 
--- Helper function to dynamically show or hide sections of a formspec
--- if a currency item is missing
-local mg = function(count, str)
-	if count == 50 and mg50_exists then
-		return str
-	elseif count == 100 and mg100_exists then
-		return str
-	else
-		return ""
-	end
-end
-
 -- abbreviation/symbol of the currency
 local MONEY_SYMBOL = "Mg" -- Mg = Minegeld
 
@@ -41,8 +29,10 @@ local create_currency_buttons = function(cols, rows, xstart, ystart, gap)
 		end
 		local multiplier = denom * (10 ^ (r-1))
 		local rowname = rownames[r]
-		formstring = formstring .. "item_image_button["..x..","..y..";1,1;"..item..";"..rowname..tostring(multiplier)..";\n\n\b\b\b\b\b"..tostring(amount).."]"
-		formstring = formstring .. "item_image_button["..xo..","..y..";1,1;"..item..";"..rowname..tostring(-multiplier)..";\n\n\b\b\b\b\b"..tostring(amount).."]"
+		formstring = formstring .. "item_image_button["..x..","..y..";1,1;"..item..";"..
+				rowname..tostring(multiplier)..";\n\n\b\b\b\b\b"..tostring(amount).."]"
+		formstring = formstring .. "item_image_button["..xo..","..y..";1,1;"..item..";"..
+				rowname..tostring(-multiplier)..";\n\n\b\b\b\b\b"..tostring(amount).."]"
 	end
 	end
 	return formstring
@@ -199,7 +189,8 @@ function atm.showform_wtlist (player, tlist)
 		textlist = "no transactions registered\n"
 	else
 		for _, entry in ipairs(tlist) do
-			textlist = textlist .. entry.date .. " " .. entry.sum .. " " .. MONEY_SYMBOL .. " from " .. entry.from .. ": " .. entry.desc .. "\n"
+			textlist = textlist .. entry.date .. " " .. entry.sum .. " " .. MONEY_SYMBOL ..
+					" from " .. entry.from .. ": " .. entry.desc .. "\n"
 		end
 	end
 

--- a/forms.lua
+++ b/forms.lua
@@ -1,5 +1,51 @@
+-- For backwards compability, check if 50 and 100 Minegeld notes exist
+local mg50_exists = minetest.registered_items["currency:minegeld_50"] ~= nil
+local mg100_exists = minetest.registered_items["currency:minegeld_100"] ~= nil
 
+-- Helper function to dynamically show or hide sections of a formspec
+-- if a currency item is missing
+local mg = function(count, str)
+	if count == 50 and mg50_exists then
+		return str
+	elseif count == 100 and mg100_exists then
+		return str
+	else
+		return ""
+	end
+end
 
+local denominations = { 1, 5, 10 }
+if mg50_exists then
+	table.insert(denominations, 50)
+end
+if mg100_exists then
+	table.insert(denominations, 100)
+end
+local rownames = { "i", "t", "c" }
+
+local create_currency_buttons = function(cols, rows, xstart, ystart, gap)
+	local formstring = ""
+	for c=1, cols do
+	for r=1, rows do
+		local amount = 10 ^ (r-1)
+		local x = xstart + (c-1)
+		local xo = x + cols + gap
+		local y = ystart + (r-1)
+		local denom = denominations[c]
+		local item = "currency:minegeld"
+		if denom > 1 then
+			item = item .. "_"..tostring(denom)
+		end
+		local multiplier = denom * (10 ^ (r-1))
+		local rowname = rownames[r]
+		formstring = formstring .. "item_image_button["..x..","..y..";1,1;"..item..";"..rowname..tostring(multiplier)..";\n\n\b\b\b\b\b"..tostring(amount).."]"
+		formstring = formstring .. "item_image_button["..xo..","..y..";1,1;"..item..";"..rowname..tostring(-multiplier)..";\n\n\b\b\b\b\b"..tostring(amount).."]"
+	end
+	end
+	return formstring
+end
+
+-- ATM model 1
 function atm.showform (player)
 	atm.read_account(player:get_player_name())
 	local formspec =
@@ -7,92 +53,93 @@ function atm.showform (player)
 	default.gui_bg..
 	default.gui_bg_img..
 	default.gui_slots..
-	"label[1.25,0.5;Money input]" ..
-	"label[5.25,0.5;Money output]" ..
+	"label[1.5,0.5;Money input]" ..
+	"label[5.5,0.5;Money output]" ..
 	"label[2.5,0.15;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
 	"button_exit[2.5,1.5;1,2;Quit;Quit]" ..
-	"item_image_button[0.5,1;1,1;".. "currency:minegeld" ..";i1;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[1.5,1;1,1;".. "currency:minegeld_5" ..";i5;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[2.5,1;1,1;".. "currency:minegeld_10" ..";i10;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[4.5,1;1,1;".. "currency:minegeld" ..";i-1;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[5.5,1;1,1;".. "currency:minegeld_5" ..";i-5;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[6.5,1;1,1;".. "currency:minegeld_10" ..";i-10;\n\n\b\b\b\b\b" .. "1" .."]" ..
+	create_currency_buttons(3, 1, 0.5, 1, 1) ..
 	"list[current_player;main;0,4.25;8,1;]"..
 	"list[current_player;main;0,5.5;8,3;8]"..
-	"listring[]"..
-      default.get_hotbar_bg(0, 4.25)
+	default.get_hotbar_bg(0, 4.25)
 	minetest.after((0.1), function(gui)
 			return minetest.show_formspec(player:get_player_name(), "atm.form", gui)
 		end, formspec)
 end
 
 
+-- ATM model 2
 function atm.showform2 (player)
 	atm.read_account(player:get_player_name())
+	local xplus = 0
+	local cols = 3
+	local listx = 0
+	local startx = 0.5
+	if mg50_exists then
+		xplus = 1
+		cols = cols + 1
+		listx = listx + 0.5
+		startx = 0
+	end
 	local formspec =
-	"size[8,8.5]"..
+	"size["..(8+xplus)..",8.5]"..
 	default.gui_bg..
 	default.gui_bg_img..
 	default.gui_slots..
 	"label[1.25,0.5;Money input]" ..
-	"label[5.25,0.5;Money output]" ..
+	"label["..(5.25+xplus)..",0.5;Money output]" ..
 	"label[2.5,0.15;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
-	"button_exit[2.5,2.5;1,2;Quit;Quit]" ..
-	"item_image_button[0.5,1;1,1;".. "currency:minegeld" ..";i1;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[1.5,1;1,1;".. "currency:minegeld_5" ..";i5;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[2.5,1;1,1;".. "currency:minegeld_10" ..";i10;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[4.5,1;1,1;".. "currency:minegeld" ..";i-1;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[5.5,1;1,1;".. "currency:minegeld_5" ..";i-5;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[6.5,1;1,1;".. "currency:minegeld_10" ..";i-10;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[0.5,2;1,1;".. "currency:minegeld" ..";t10;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[1.5,2;1,1;".. "currency:minegeld_5" ..";t50;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[2.5,2;1,1;".. "currency:minegeld_10" ..";t100;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[4.5,2;1,1;".. "currency:minegeld" ..";t-10;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[5.5,2;1,1;".. "currency:minegeld_5" ..";t-50;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[6.5,2;1,1;".. "currency:minegeld_10" ..";t-100;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"list[current_player;main;0,4.25;8,1;]"..
-	"list[current_player;main;0,5.5;8,3;8]"..
-	"listring[]"..
-	default.get_hotbar_bg(0, 4.25)
+	"button_exit["..(4+xplus)..",2.5;1,2;Quit;Quit]" ..
+	create_currency_buttons(cols, 2, startx, 1, 1) ..
+	"list[current_player;main;"..(listx)..",4.25;8,1;]"..
+	"list[current_player;main;"..(listx)..",5.5;8,3;8]"..
+	default.get_hotbar_bg(listx, 4.25)
 	minetest.after((0.1), function(gui)
 			return minetest.show_formspec(player:get_player_name(), "atm.form2", gui)
 		end, formspec)
 end
 
 
+-- ATM model 3
 function atm.showform3 (player)
 	atm.read_account(player:get_player_name())
+	local xplus = 0
+	local xplus_out = 0
+	local cols = 3
+	local listx = 0
+	local gap = 1
+	local xstart = 0
+	if mg50_exists then
+		xplus = xplus + 1
+		xplus_out = 0.5
+		listx = listx + 0.5
+		cols = cols + 1
+		gap = 1
+	end
+	if mg100_exists then
+		xplus = xplus + 1.5
+		listx = listx + 0.5
+		cols = cols + 1
+		gap = 0.5
+	end
+	if mg50_exists and mg100_exists then
+		xplus_out = 1
+	end
+	if not mg50_exists and not mg100_exists then
+		xstart = 0.5
+	end
 	local formspec =
-	"size[8,8.5]"..
+	"size["..(8+xplus)..",8.5]"..
 	default.gui_bg..
 	default.gui_bg_img..
 	default.gui_slots..
 	"label[1.25,0.5;Money input]" ..
-	"label[5.25,0.5;Money output]" ..
+	"label["..(5.75+xplus_out)..",0.5;Money output]" ..
 	"label[2.5,0.15;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
-	"button_exit[3.5,2.75;1,2;Quit;Quit]" ..
-	"item_image_button[0.5,1;1,1;".. "currency:minegeld" ..";i1;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[1.5,1;1,1;".. "currency:minegeld_5" ..";i5;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[2.5,1;1,1;".. "currency:minegeld_10" ..";i10;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[4.5,1;1,1;".. "currency:minegeld" ..";i-1;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[5.5,1;1,1;".. "currency:minegeld_5" ..";i-5;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[6.5,1;1,1;".. "currency:minegeld_10" ..";i-10;\n\n\b\b\b\b\b" .. "1" .."]" ..
-	"item_image_button[0.5,2;1,1;".. "currency:minegeld" ..";t10;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[1.5,2;1,1;".. "currency:minegeld_5" ..";t50;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[2.5,2;1,1;".. "currency:minegeld_10" ..";t100;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[4.5,2;1,1;".. "currency:minegeld" ..";t-10;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[5.5,2;1,1;".. "currency:minegeld_5" ..";t-50;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[6.5,2;1,1;".. "currency:minegeld_10" ..";t-100;\n\n\b\b\b\b\b" .. "10" .."]" ..
-	"item_image_button[0.5,3;1,1;".. "currency:minegeld" ..";c100;\n\n\b\b\b\b\b" .. "100" .."]" ..
-	"item_image_button[1.5,3;1,1;".. "currency:minegeld_5" ..";c500;\n\n\b\b\b\b\b" .. "100" .."]" ..
-	"item_image_button[2.5,3;1,1;".. "currency:minegeld_10" ..";c1000;\n\n\b\b\b\b\b" .. "100" .."]" ..
-	"item_image_button[4.5,3;1,1;".. "currency:minegeld" ..";c-100;\n\n\b\b\b\b\b" .. "100" .."]" ..
-	"item_image_button[5.5,3;1,1;".. "currency:minegeld_5" ..";c-500;\n\n\b\b\b\b\b" .. "100" .."]" ..
-	"item_image_button[6.5,3;1,1;".. "currency:minegeld_10" ..";c-1000;\n\n\b\b\b\b\b" .. "100" .."]" ..
-	"list[current_player;main;0,4.25;8,1;]"..
-	"list[current_player;main;0,5.5;8,3;8]"..
-	"listring[]"..
-	default.get_hotbar_bg(0, 4.25)
+	"button_exit["..(7+xplus)..",-0.5;1,2;Quit;Quit]" ..
+	create_currency_buttons(cols, 3, xstart, 1, gap) ..
+	"list[current_player;main;"..listx..",4.25;8,1;]"..
+	"list[current_player;main;"..listx..",5.5;8,3;8]"..
+	default.get_hotbar_bg(listx, 4.25)
 	minetest.after((0.1), function(gui)
 			return minetest.show_formspec(player:get_player_name(), "atm.form3", gui)
 		end, formspec)

--- a/receive_fields.lua
+++ b/receive_fields.lua
@@ -10,7 +10,7 @@ minetest.register_on_player_receive_fields(function(player, form, pressed)
 		local pinv=player:get_inventory()
 
 		-- single note transactions
-		for _,i in pairs({1, 5, 10, -1, -5, -10}) do
+		for _,i in pairs({1, 5, 10, 50, 100, -1, -5, -10, -50, -100}) do
 			if pressed["i"..i] then
 				transaction.amount = i
 				transaction.denomination = '_' .. math.abs(i)
@@ -23,7 +23,7 @@ minetest.register_on_player_receive_fields(function(player, form, pressed)
 		end
 
 		-- 10x banknote transactions
-		for _,t in pairs({10, 50, 100, -10, -50, -100}) do
+		for _,t in pairs({10, 50, 100, 500, 1000, -10, -50, -100, -500, -1000}) do
 			if pressed["t"..t] then
 				transaction.amount = t
 				transaction.denomination = '_' .. math.abs(t/10)
@@ -36,7 +36,7 @@ minetest.register_on_player_receive_fields(function(player, form, pressed)
 		end
 
 		-- 100x banknote transactions
-		for _,c in pairs({100, 500, 1000, -100, -500, -1000}) do
+		for _,c in pairs({100, 500, 1000, 5000, 10000, -100, -500, -1000, -5000, -10000}) do
 			if pressed["c"..c] then
 				transaction.amount = c
 				transaction.denomination = '_' .. math.abs(c/100)


### PR DESCRIPTION
Fixes #12.

ATM model 2 accepts 50 Minegeld notes and ATM model 3 accepts 50+100 Minegeld notes.

Also, the code checks if the currency mod actually does have these items and if not, automatically fixes the ATM formspecs. Because the 50/100 Minegeld notes were added in later versions of currency.